### PR TITLE
fix(detection): check main thread before registering signal handlers

### DIFF
--- a/src/queue_monitor/pipeline.py
+++ b/src/queue_monitor/pipeline.py
@@ -230,11 +230,11 @@ class Pipeline:
     def run(self, show_window: bool = False) -> None:
         """Run the main processing loop."""
         self._running = True
-        try:
+        if threading.current_thread() is threading.main_thread():
             signal.signal(signal.SIGINT, self._handle_signal)
             signal.signal(signal.SIGTERM, self._handle_signal)
-        except ValueError:
-            pass  # Not in main thread (e.g., --web mode)
+        else:
+            logger.debug("signal_registration_skipped", reason="not main thread")
 
         self._source.open()
         self._db.open()

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,5 +1,6 @@
 """Tests for the processing pipeline (integration-style with mocks)."""
 
+import threading
 from unittest.mock import MagicMock, patch
 
 import numpy as np
@@ -155,3 +156,56 @@ def test_run_stores_error_on_crash(mock_detector_cls, tmp_path):
     assert pipeline.error is not None
     assert pipeline.error.message == "source failed"
     assert not pipeline.is_running
+
+
+@patch("queue_monitor.pipeline.PersonDetector")
+def test_run_registers_signals_in_main_thread(mock_detector_cls, tmp_path):
+    """Signal handlers are registered when running on the main thread."""
+    config = AppConfig()
+    config.storage.database = str(tmp_path / "test.db")
+    mock_detector_cls.return_value = MagicMock()
+
+    pipeline = Pipeline(config)
+
+    mock_source = MagicMock()
+    mock_source.open.return_value = None
+    mock_source.frame_size = (1280, 720)
+    mock_source.fps = 30
+    mock_source.__iter__ = MagicMock(return_value=iter([]))
+    pipeline._source = mock_source
+
+    with patch("queue_monitor.pipeline.signal.signal") as mock_signal:
+        pipeline.run()
+        assert mock_signal.call_count == 2
+
+
+@patch("queue_monitor.pipeline.PersonDetector")
+def test_run_skips_signals_in_non_main_thread(mock_detector_cls, tmp_path):
+    """Signal handlers are skipped (with log) when not on the main thread."""
+    config = AppConfig()
+    config.storage.database = str(tmp_path / "test.db")
+    mock_detector_cls.return_value = MagicMock()
+
+    pipeline = Pipeline(config)
+
+    mock_source = MagicMock()
+    mock_source.open.return_value = None
+    mock_source.frame_size = (1280, 720)
+    mock_source.fps = 30
+    mock_source.__iter__ = MagicMock(return_value=iter([]))
+    pipeline._source = mock_source
+
+    errors = []
+
+    def run_in_thread():
+        try:
+            with patch("queue_monitor.pipeline.signal.signal") as mock_signal:
+                pipeline.run()
+                assert mock_signal.call_count == 0
+        except AssertionError as e:
+            errors.append(e)
+
+    t = threading.Thread(target=run_in_thread)
+    t.start()
+    t.join(timeout=5)
+    assert not errors, f"Thread raised: {errors}"


### PR DESCRIPTION
## Summary
- Replace `try/except ValueError: pass` with an explicit `threading.current_thread() is threading.main_thread()` check before calling `signal.signal()`
- Unexpected `ValueError`s are no longer silently swallowed
- Log at debug level when signal registration is skipped (non-main thread)

Closes #5

## Test plan
- [x] `test_run_registers_signals_in_main_thread` — verifies signal handlers are registered when on main thread
- [x] `test_run_skips_signals_in_non_main_thread` — verifies signal handlers are skipped when running in a worker thread
- [x] All 89 tests pass, ruff clean