### PR TITLE
fix(detection): cap departed list to prevent unbounded memory growth

### DIFF
--- a/src/queue_monitor/detection/tracker.py
+++ b/src/queue_monitor/detection/tracker.py
@@ -10,11 +10,12 @@ import supervision as sv
 class QueueTracker:
     """Track people across frames and record dwell times."""
 
-    def __init__(self):
+    def __init__(self, max_departures: int = 1000):
         self._tracker = sv.ByteTrack()
         self._entry_times: dict[int, float] = {}
         self._active_ids: set[int] = set()
         self._departed: list[float] = []  # dwell times of departed tracks
+        self._max_departures = max_departures
 
     def update(self, detections: sv.Detections) -> sv.Detections:
         """Update tracker with new detections, return tracked detections."""
@@ -34,6 +35,10 @@ class QueueTracker:
             if tid in self._entry_times:
                 dwell = now - self._entry_times.pop(tid)
                 self._departed.append(dwell)
+
+        # Cap departed list to prevent unbounded memory growth
+        if len(self._departed) > self._max_departures:
+            self._departed = self._departed[-self._max_departures :]
 
         self._active_ids = current_ids
         return tracked

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -90,3 +90,57 @@ def test_tracker_reset():
     tracker.reset()
     assert tracker.active_count == 0
     assert tracker.pop_departures() == []
+
+
+def test_departed_list_bounded():
+    """Departed list never exceeds max_departures."""
+    tracker = QueueTracker(max_departures=5)
+
+    with patch.object(tracker, "_tracker") as mock_bt:
+        for i in range(10):
+            # Person enters
+            mock_bt.update_with_detections.return_value = _make_tracked_detections([i])
+            tracker.update(
+                sv.Detections(
+                    xyxy=np.array([[0, 0, 50, 50]], dtype=np.float32),
+                    confidence=np.array([0.9], dtype=np.float32),
+                    class_id=np.array([0], dtype=int),
+                )
+            )
+            # Person leaves
+            empty = sv.Detections.empty()
+            empty.tracker_id = np.array([], dtype=int)
+            mock_bt.update_with_detections.return_value = empty
+            tracker.update(sv.Detections.empty())
+
+    assert len(tracker._departed) <= 5
+
+
+def test_departed_list_keeps_newest():
+    """When capped, the most recent dwell times are kept."""
+    tracker = QueueTracker(max_departures=3)
+
+    # Directly populate to test trimming behavior
+    tracker._departed = [1.0, 2.0, 3.0, 4.0, 5.0]
+    # Simulate an update that triggers trimming
+    with patch.object(tracker, "_tracker") as mock_bt:
+        # Person enters then leaves to trigger the trim path
+        mock_bt.update_with_detections.return_value = _make_tracked_detections([99])
+        tracker.update(
+            sv.Detections(
+                xyxy=np.array([[0, 0, 50, 50]], dtype=np.float32),
+                confidence=np.array([0.9], dtype=np.float32),
+                class_id=np.array([0], dtype=int),
+            )
+        )
+        empty = sv.Detections.empty()
+        empty.tracker_id = np.array([], dtype=int)
+        mock_bt.update_with_detections.return_value = empty
+        tracker.update(sv.Detections.empty())
+
+    departed = tracker._departed
+    assert len(departed) == 3
+    # Should keep the 3 newest: 5.0, and the new dwell time for track 99
+    assert 1.0 not in departed
+    assert 2.0 not in departed
+    assert 3.0 not in departed


### PR DESCRIPTION
## Summary
- Add `max_departures` parameter (default 1000) to `QueueTracker` to bound the `_departed` dwell-times list
- When the list exceeds the cap during `update()`, oldest entries are trimmed, keeping the most recent
- Backward compatible — existing callers use the default without changes

Closes #6

## Test plan
- [x] `test_departed_list_bounded` — verifies list never exceeds `max_departures` after many enter/leave cycles
- [x] `test_departed_list_keeps_newest` — verifies oldest entries are dropped and newest retained when trimmed
- [x] All existing tracker tests still pass, ruff clean