### PR TITLE
fix(cli): release previous VideoCapture before reopening

### DIFF
--- a/src/queue_monitor/video/source.py
+++ b/src/queue_monitor/video/source.py
@@ -32,6 +32,7 @@ class VideoSource:
 
     def open(self) -> None:
         """Open the video source."""
+        self.release()
         self._cap = cv2.VideoCapture(self._source)
         if isinstance(self._source, int):
             self._cap.set(cv2.CAP_PROP_FRAME_WIDTH, self._config.width)

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -229,3 +229,22 @@ def test_iterator_stops_on_failure(mock_cv2):
     vs.open()
     frames = list(vs)
     assert frames == []
+
+
+@patch("queue_monitor.video.source.cv2")
+def test_open_releases_previous_capture(mock_cv2):
+    from queue_monitor.video.source import VideoSource
+
+    first_cap = MagicMock()
+    first_cap.isOpened.return_value = True
+    second_cap = MagicMock()
+    second_cap.isOpened.return_value = True
+    mock_cv2.VideoCapture.side_effect = [first_cap, second_cap]
+
+    vs = VideoSource(VideoConfig(source="video.mp4"))
+    vs.open()
+    assert vs._cap is first_cap
+
+    vs.open()
+    first_cap.release.assert_called_once()
+    assert vs._cap is second_cap


### PR DESCRIPTION
## Summary
- Call `self.release()` at the start of `VideoSource.open()` so that calling `open()` multiple times no longer leaks the previous `cv2.VideoCapture` object
- Safe because `release()` is already idempotent (no-op when `_cap` is `None`)

Closes #7

## Test plan
- [x] `test_open_releases_previous_capture` — calls `open()` twice, verifies the first capture is released before the second is created
- [x] All 18 source tests pass, ruff clean